### PR TITLE
Info about issue with outgoing server

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ This extension allows the use of CatchAll-Addresses with Thunderbird.
 https://addons.thunderbird.net/de/thunderbird/addon/catchall-bird/
 
 ## Important Limitation: Please Note
+Short:
+1. The catch-all mail address must be the default SMTP server for the whole installation.
+2. It's likely only possible to have a single catch-all mail address enabled.
+
 It came to my attention that there is an issue with thunderbird when multiple email accounts are present (or maybe even were present). Thanks to @alex9099 at issue [6](https://github.com/Jabb0/CatchAllBird/issues/6).
 This should not affect you if you have only used the catch-all account in your thunderbird installation and no second account.
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,23 @@ This extension allows the use of CatchAll-Addresses with Thunderbird.
 
 https://addons.thunderbird.net/de/thunderbird/addon/catchall-bird/
 
+## Important Limitation: Please Note
+It came to my attention that there is an issue with thunderbird when multiple email accounts are present (or maybe even were present). Thanks to @alex9099 at issue [6](https://github.com/Jabb0/CatchAllBird/issues/6).
+This should not affect you if you have only used the catch-all account in your thunderbird installation and no second account.
+
+Due to limitations in thunderbirds AddOn API all new identities will use the default SMTP server for outgoing mails. 
+But for Thunderbird this is a global default server instead of the one for the mail account (usually the SMTP server of the first email account created in the installation). This means that identities created by this AddOn might not use the correct outgoing SMTP server.
+They will use the default SMTP server at the time of sending the email. 
+
+It is not possible to see or change the SMTP server via the interface the AddOn can access. Even though the main identity of a mail account is copied the server is not preserved.
+
+Until this is fixed by the thunderbird team the only mitigation is to set the default SMTP server to the server of your catch-all address.
+Change the default SMTP server via Account-Settings -> Outgoing Server (SMTP) -> <Your catch-all SMTP Server> -> Set Default.
+
+If this does not work for you please disable the AddOn for the conflicting email accounts and go to Account-Settings -> <Your Account> -> Manage Identities and delete the identities created by the AddOn.
+Sorry for the inconvenience.
+
+# Description
 It handles incoming messages addressed to all `<prefix>@domain.tld` for a fixed domain.
 
 As such, the features are:

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ They will use the default SMTP server at the time of sending the email.
 It is not possible to see or change the SMTP server via the interface the AddOn can access. Even though the main identity of a mail account is copied the server is not preserved.
 
 Until this is fixed by the thunderbird team the only mitigation is to set the default SMTP server to the server of your catch-all address.
-Change the default SMTP server via Account-Settings -> Outgoing Server (SMTP) -> <Your catch-all SMTP Server> -> Set Default.
+Change the default SMTP server via `Account-Settings -> Outgoing Server (SMTP) -> <Your catch-all SMTP Server> -> Set Default`.
 
-If this does not work for you please disable the AddOn for the conflicting email accounts and go to Account-Settings -> <Your Account> -> Manage Identities and delete the identities created by the AddOn.
+If this does not work for you please disable the AddOn for the conflicting email accounts and go to `Account-Settings -> <Your Account> -> Manage Identities` and delete the identities created by the AddOn.
 Sorry for the inconvenience.
 
 # Description

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -184,7 +184,24 @@ async function processInbox() {
     }
 }
 
+ async function welcomeTab() {
+    await messenger.tabs.create({
+        url: "../popup/popup.html",
+        index: 1
+    });
+ }
+
 async function load() {
+    const { 
+        catchAllBirdHideWelcomeMessage: hideWelcomeMessage
+    } = await messenger.storage.local.get({
+        catchAllBirdHideWelcomeMessage: false
+    });
+
+    if (!hideWelcomeMessage) {
+        await welcomeTab();
+    }
+
     // Setup menu button for reprocessing inbox
     const menu_id = await messenger.menus.create({
         title: "CatchAll Bird: Process INBOX",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 2,
     "name": "CatchAll Bird",
     "description": "Enable Thunderbird to handle CatchAll email addresses.",
-    "version": "1.0.6",
+    "version": "1.0.7",
     "author": "Jabb0",
     "applications": {
         "gecko": {

--- a/src/optionsPage/options.html
+++ b/src/optionsPage/options.html
@@ -8,6 +8,9 @@
 </head>
 <body>
     <h2>Account Settings</h2>
+    <strong>Important:</strong>Due to limitations in Thunderbird the catch-all account needs to be the default SMTP server! Change this in the account settings of Thunderbird.
+    All identities created by this AddOn will use the current global default SMTP server for outgoing mails. Hopefully, this will be changed in future versions of Thunderbird.
+    <strong>Further, because of this only a single catch-all address can be used when using identities.</strong>
     <table id="main-table">
         <tr>
             <th scope="col">Id</th>

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -24,9 +24,9 @@
     </p>
 
     <h4>Short Version</h4>
-    Due to a limitation of the Thunderbird AddOn interface, the outgoing mail server (SMTP) of the catch-all account needs to be the default outgoing mail server for the whole installation.<br>
+    Due to a limitation of the Thunderbird AddOn interface, <b>the outgoing mail server (SMTP) of the catch-all account needs to be the default outgoing mail server</b> for the whole installation.<br>
     This default server can be changed in the settings (see section "What to do?").<br>
-    Further, because of this it is only possible to have a single catch-all address when using the automatic identity creation feature.<br>
+    Further, because of this <b>it is only possible to have a single catch-all address enabled</b> when using the automatic identity creation feature.<br>
     This is because when sending using an identity created by this AddOn the (at time of sending) default outgoing mail server of the Thunderbird installation is used.
     With the currently available AddOn interfaces this cannot be changed.
 
@@ -63,6 +63,7 @@
 
     <br><br>
     Sorry for the inconvenience.<br>
-    Further details and discussion can be found on the <a href="https://github.com/Jabb0/CatchAllBird">GitHub</a>.
+    I hope this explanation has been clear.
+    For further questions, details and discussion please go to the <a href="https://github.com/Jabb0/CatchAllBird">GitHub</a>.
   </body>
 </html>

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN"
+                      "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd"
+>
+
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <meta charset="UTF-8" />
+    <title>CatchAll-Bird Important Info</title>
+    <script src="popup.js"></script>      
+  </head>
+  <body>
+    <h1>CatchAll-Bird - Important Info</h1>
+    
+    <p>
+        <label>Don't show again: </label><input id="checkbox_noshow" type="checkbox" data="true">
+    </p>
+
+    <p>
+        Dear CatchAll-Bird user. Thank you for using this AddOn.
+    </p>
+
+    <p>
+        Please note this <b>important</b> limitation regarding the automatic identity creation, that recently came to my attention.
+    </p>
+
+    <h4>Short Version</h4>
+    Due to a limitation of the Thunderbird AddOn interface, the outgoing mail server (SMTP) of the catch-all account needs to be the default outgoing mail server for the whole installation.<br>
+    This default server can be changed in the settings (see section "What to do?").<br>
+    Further, because of this it is only possible to have a single catch-all address when using the automatic identity creation feature.<br>
+    This is because when sending using an identity created by this AddOn the (at time of sending) default outgoing mail server of the Thunderbird installation is used.
+    With the currently available AddOn interfaces this cannot be changed.
+
+    <h3>What happens?</h3>
+    Due to a missing feature in the Thunderbird AddOn interface, the outgoing mail server (SMTP) might not be set as expected for identites created by this AddOn.<br>
+    <br>
+    A mail account is each account you setup in Thunderbird (e.g. you@yourdomain.com or you@yourdomain2.net or you@publicmailprovider.com).
+    <br><br>
+    By design each new identity for a prefix is a copy of the first (main) identity of the mail account (except for the new prefix email).<br>
+    This way the identity settings you made for this mail account should be preserved.<br><br>
+    However, there is no way of specifying the per-identity outgoing mail server (SMTP) for an new identity.<br>
+    And instead of using the known outgoing server of the mail account, Thunderbird uses the default outgoing mail server of the whole installation (at time of sending).
+    <br><br>
+    This is an issue if the default outgoing mail server is not the one for your catch-all email account.<br>
+    If this is not the case Thunderbird will try to send your responses to prefix emails via the wrong outgoing mail server.
+
+    <h3>Who is effected?</h3>
+    This issue affects users that do not have their catch-all address as default outgoing mail server (SMTP) in the Thunderbird settings <b>or</b> have multiple catch-all addresses.<br>
+    This is most likely the case if another mail account is present before the catch-all mail account.<br>
+    <br>
+    You can check the current default outgoing mail server at: Tools -> Account Settings -> Outgoing Server (SMTP)
+
+    <h3>What to do?</h3>
+    Until Thunderbird adds the required interface (or changes the default behaviour) the options are limited. Due to the missing interface this step needs to be manual.<br><br>
+
+    Change the default SMTP server at<br>
+    Account-Settings -> Outgoing Server (SMTP) -> Your catch-all account SMTP Server -> Set Default<br>
+    
+    Further, (in my opinion) this mean that only a single catch-all address can be used, because the login credentials are part of the SMTP server config.<br>
+    <br>
+    If this does not work for you please disable the AddOn for this account and go to Account-Settings -> Your Mail Account -> Manage Identities and delete the identities created by the AddOn.<br>
+    Otherwise, when using these identities the current default outgoing mail server will be used as described above.<br>
+    <b>Alternatively</b>, manually change the SMTP server inside each of the identities.
+
+    <br><br>
+    Sorry for the inconvenience.<br>
+    Further details and discussion can be found on the <a href="https://github.com/Jabb0/CatchAllBird">GitHub</a>.
+  </body>
+</html>

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -1,0 +1,9 @@
+window.addEventListener("load", onLoad);
+ 
+async function noShowCheckBoxClicked(event) {
+    await messenger.storage.local.set({ catchAllBirdHideWelcomeMessage: this.checked });
+}
+
+async function onLoad() {
+   document.getElementById("checkbox_noshow").addEventListener("change", noShowCheckBoxClicked);
+}


### PR DESCRIPTION
After report from @alex9099 in #6 it became clear that Thunderbird has an unexpected default value in the AddOn API for creating new identities.

All new identities have the installation-wide default SMTP server instead of the mail account specific one (as one would expect).

With this update the users are informed of the fact and advised to set the default SMTP server to their catch-all one.