### PR TITLE
Make compatible with Thunderbird 128

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.xpi
 .DS_Store
 node_modules
+build

--- a/package-lock.json
+++ b/package-lock.json
@@ -1420,12 +1420,13 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -1957,10 +1958,11 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -2302,6 +2304,7 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
       }
@@ -3243,12 +3246,13 @@
       "dev": true
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {
@@ -4003,6 +4007,7 @@
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
       },

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -22,6 +22,7 @@ async function welcomeTab() {
         contexts: [
             "tools_menu"
         ],
+        id: "catchallbirdMenuItemProcessInbox"
     });
  
     await messenger.menus.onClicked.addListener(async (info, tab) => {
@@ -39,14 +40,17 @@ async function welcomeTab() {
         contexts: [
             "folder_pane"
         ],
+        id: "catchallbirdMenuItemProcessFolder"
     });
  
     await messenger.menus.onClicked.addListener(async (info, tab) => {
         if (info.menuItemId == menu_id) {
-            const { selectedFolder } = info;
+            const { selectedFolders } = info;
  
-            if (!!selectedFolder) {
-                processMessagesInFolder(selectedFolder);
+            if (!!selectedFolders) {
+                for (const folder of selectedFolders) {
+                    processMessagesInFolder(folder);
+                }
             }
         }
     });

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,13 +1,13 @@
 {
-    "manifest_version": 2,
+    "manifest_version": 3,
     "name": "CatchAll Bird",
     "description": "Enable Thunderbird to handle CatchAll email addresses.",
-    "version": "1.1.2",
+    "version": "1.2.0",
     "author": "Jabb0",
     "browser_specific_settings": {
         "gecko": {
             "id": "catchallbird@jabb0",
-            "strict_min_version": "78.0"
+            "strict_min_version": "128.0"
         }
     },
     "background": {
@@ -15,8 +15,7 @@
     },
     "options_ui": {
         "page": "optionsPage/options.html",
-        "open_in_tab": false,
-        "browser_style": true
+        "open_in_tab": false
     },
     "permissions": [
         "messagesRead",

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -151,6 +151,7 @@ describe("moveMessages()", function() {
             accountId: "blaa",
             path: "blub",
             name: "blub",
+            id: "parentFolderId"
             // subFolders: []
         }
         messenger.folders.getSubFolders.mockImplementation(async () => {
@@ -166,6 +167,7 @@ describe("moveMessages()", function() {
             accountId: "blaa",
             path: "blub.peter",
             name: "peter",
+            folderId: "xyz"
             // subFolders: []
         }
 
@@ -176,9 +178,9 @@ describe("moveMessages()", function() {
 
         moveMessages(parentFolder, mailMapping);
 
-        await expect(messenger.folders.getSubFolders).toHaveBeenCalledWith(parentFolder, false);
-        await expect(messenger.folders.create).toHaveBeenCalledWith(parentFolder, "peter");
-        await expect(messenger.messages.move).toHaveBeenCalledWith(mailIds, newFolder);
+        await expect(messenger.folders.getSubFolders).toHaveBeenCalledWith(parentFolder.id, false);
+        await expect(messenger.folders.create).toHaveBeenCalledWith(parentFolder.id, "peter");
+        await expect(messenger.messages.move).toHaveBeenCalledWith(mailIds, newFolder.id);
     })
 
     it("should create new folder with dot replacement if necessary", async function() {
@@ -186,6 +188,7 @@ describe("moveMessages()", function() {
             accountId: "blaa",
             path: "blub",
             name: "blub",
+            id: "parentFolderId"
             // subFolders: []
         }
         messenger.folders.getSubFolders.mockImplementation(async () => {
@@ -201,6 +204,7 @@ describe("moveMessages()", function() {
             accountId: "blaa",
             path: "blub.peterDOThansDOTwurst",
             name: "peterDOThansDOTwurst",
+            id: "xyz"
             // subFolders: []
         }
 
@@ -211,8 +215,8 @@ describe("moveMessages()", function() {
 
         moveMessages(parentFolder, mailMapping);
 
-        await expect(messenger.folders.getSubFolders).toHaveBeenCalledWith(parentFolder, false);
-        await expect(messenger.folders.create).toHaveBeenCalledWith(parentFolder, "peterDOThansDOTwurst");
-        await expect(messenger.messages.move).toHaveBeenCalledWith(mailIds, newFolder);
+        await expect(messenger.folders.getSubFolders).toHaveBeenCalledWith(parentFolder.id, false);
+        await expect(messenger.folders.create).toHaveBeenCalledWith(parentFolder.id, "peterDOThansDOTwurst");
+        await expect(messenger.messages.move).toHaveBeenCalledWith(mailIds, newFolder.id);
     })
 });


### PR DESCRIPTION
- make compatible with Thunderbird v128
- change to manifestV3
- npm audit fixes

First of all, thank you for your work on this extension.
When I tried to test it with Thunderbird v128, I got the attached error messages. The latest Thunderbird version seems to no longer fully support some parts of v2. 
The PR is my first work with Thunderbird extensions, so I may have overlooked something.

Fixed errors:
![messages_ ist](https://github.com/user-attachments/assets/5dd6c7d9-a342-4ad3-b780-0c358f2c9ae2)
![deprecated](https://github.com/user-attachments/assets/f3a28dc3-ce50-4e23-96ed-aee8d1ddbafe)
![deprecated2](https://github.com/user-attachments/assets/60be9c99-2197-47e6-b95c-9a6373dde945)
