### PR TITLE
Make compatible with Thunderbird 128

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.xpi
 .DS_Store
 node_modules
+build

--- a/package-lock.json
+++ b/package-lock.json
@@ -1420,12 +1420,13 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -1957,10 +1958,11 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -2302,6 +2304,7 @@
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
       }
@@ -3243,12 +3246,13 @@
       "dev": true
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {
@@ -4003,6 +4007,7 @@
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
       },

--- a/src/background/background.html
+++ b/src/background/background.html
@@ -1,7 +1,0 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <meta charset="utf-8"/>
-    <script src="background.js" type="module"></script>
-</head>
-</html>

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -7,37 +7,40 @@
 
 import { processInbox, processMessagesInFolder, onNewMailReceived} from "./processing.js";
 
+const MENU_ITEM_ID_PROCESS_FOLDER = "catchallbirdMenuItemProcessFolder"
+const MENU_ITEM_ID_PROCESS_INBOX = "catchallbirdMenuItemProcessInbox"
+
 async function welcomeTab() {
     await messenger.tabs.create({
         url: "../popup/popup.html",
         index: 1
     });
- }
+}
 
- async function addMenuItemProcessInbox() {
+async function addMenuItemProcessInbox() {
     // Setup menu button for reprocessing inbox
-    const menu_id = await messenger.menus.create({
+    await messenger.menus.create({
         title: "CatchAll Bird: Process INBOX",
         contexts: [
             "tools_menu"
         ],
-        id: "catchallbirdMenuItemProcessInbox"
+        id: MENU_ITEM_ID_PROCESS_INBOX
     });
- }
+}
 
- async function addMenuItemProcessFolder() {
+async function addMenuItemProcessFolder() {
     // Setup menu button for processing a specific folder
-    const menu_id = await messenger.menus.create({
+    await messenger.menus.create({
         title: "CatchAll Bird: Process this folder",
         contexts: [
             "folder_pane"
         ],
-        id: "catchallbirdMenuItemProcessFolder"
+        id: MENU_ITEM_ID_PROCESS_FOLDER
     });
- }
+}
 
 async function load() {
-    const { 
+    const {
         catchAllBirdHideWelcomeMessage: hideWelcomeMessage
     } = await messenger.storage.local.get({
         catchAllBirdHideWelcomeMessage: false
@@ -60,7 +63,7 @@ async function load() {
 messenger.messages.onNewMailReceived.addListener(onNewMailReceived);
 
 messenger.menus.onClicked.addListener(async (info, tab) => {
-    if (info.menuItemId == "catchallbirdMenuItemProcessFolder") {
+    if (info.menuItemId == MENU_ITEM_ID_PROCESS_FOLDER) {
         const { selectedFolders } = info;
 
         if (!!selectedFolders) {
@@ -72,7 +75,7 @@ messenger.menus.onClicked.addListener(async (info, tab) => {
 });
 
 messenger.menus.onClicked.addListener(async (info, tab) => {
-    if (info.menuItemId == "catchallbirdMenuItemProcessInbox") {
+    if (info.menuItemId == MENU_ITEM_ID_PROCESS_INBOX) {
         await processInbox();
     }
 });

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -13,8 +13,7 @@ async function welcomeTab() {
         index: 1
     });
  }
- 
- 
+
  async function addMenuItemProcessInbox() {
     // Setup menu button for reprocessing inbox
     const menu_id = await messenger.menus.create({
@@ -24,15 +23,8 @@ async function welcomeTab() {
         ],
         id: "catchallbirdMenuItemProcessInbox"
     });
- 
-    await messenger.menus.onClicked.addListener(async (info, tab) => {
-        if (info.menuItemId == menu_id) {
-            await processInbox();
-        }
-    });
  }
- 
- 
+
  async function addMenuItemProcessFolder() {
     // Setup menu button for processing a specific folder
     const menu_id = await messenger.menus.create({
@@ -42,20 +34,7 @@ async function welcomeTab() {
         ],
         id: "catchallbirdMenuItemProcessFolder"
     });
- 
-    await messenger.menus.onClicked.addListener(async (info, tab) => {
-        if (info.menuItemId == menu_id) {
-            const { selectedFolders } = info;
- 
-            if (!!selectedFolders) {
-                for (const folder of selectedFolders) {
-                    processMessagesInFolder(folder);
-                }
-            }
-        }
-    });
  }
-
 
 async function load() {
     const { 
@@ -70,11 +49,32 @@ async function load() {
 
     await addMenuItemProcessInbox();
     await addMenuItemProcessFolder();
+};
 
-    // Add a listener for the onNewMailReceived events.
-    // On each new message decide what to do
-    // Messages are already filtered by junk classification and message filters
-    await messenger.messages.onNewMailReceived.addListener(onNewMailReceived);
-}
+// listener creation has to be on top level to work with manifest v3 
+// https://developer.chrome.com/docs/extensions/develop/migrate/to-service-workers#register-listeners
+
+// Add a listener for the onNewMailReceived events.
+// On each new message decide what to do
+// Messages are already filtered by junk classification and message filters
+messenger.messages.onNewMailReceived.addListener(onNewMailReceived);
+
+messenger.menus.onClicked.addListener(async (info, tab) => {
+    if (info.menuItemId == "catchallbirdMenuItemProcessFolder") {
+        const { selectedFolders } = info;
+
+        if (!!selectedFolders) {
+            for (const folder of selectedFolders) {
+                processMessagesInFolder(folder);
+            }
+        }
+    }
+});
+
+messenger.menus.onClicked.addListener(async (info, tab) => {
+    if (info.menuItemId == "catchallbirdMenuItemProcessInbox") {
+        await processInbox();
+    }
+});
 
 document.addEventListener("DOMContentLoaded", load);

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -22,6 +22,7 @@ async function welcomeTab() {
         contexts: [
             "tools_menu"
         ],
+        id: "catchallbirdMenuItemProcessInbox"
     });
  
     await messenger.menus.onClicked.addListener(async (info, tab) => {
@@ -39,14 +40,17 @@ async function welcomeTab() {
         contexts: [
             "folder_pane"
         ],
+        id: "catchallbirdMenuItemProcessFolder"
     });
  
     await messenger.menus.onClicked.addListener(async (info, tab) => {
         if (info.menuItemId == menu_id) {
-            const { selectedFolder } = info;
+            const { selectedFolders } = info;
  
-            if (!!selectedFolder) {
-                processMessagesInFolder(selectedFolder);
+            if (!!selectedFolders) {
+                for (const folder of selectedFolders) {
+                    processMessagesInFolder(folder);
+                }
             }
         }
     });

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -11,7 +11,8 @@
         }
     },
     "background": {
-        "page": "background/background.html"
+        "scripts": ["background/background.js"],
+        "type": "module"
     },
     "options_ui": {
         "page": "optionsPage/options.html",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,13 +1,13 @@
 {
-    "manifest_version": 2,
+    "manifest_version": 3,
     "name": "CatchAll Bird",
     "description": "Enable Thunderbird to handle CatchAll email addresses.",
-    "version": "1.1.2",
+    "version": "1.2.0",
     "author": "Jabb0",
     "browser_specific_settings": {
         "gecko": {
             "id": "catchallbird@jabb0",
-            "strict_min_version": "78.0"
+            "strict_min_version": "128.0"
         }
     },
     "background": {
@@ -15,8 +15,7 @@
     },
     "options_ui": {
         "page": "optionsPage/options.html",
-        "open_in_tab": false,
-        "browser_style": true
+        "open_in_tab": false
     },
     "permissions": [
         "messagesRead",

--- a/tests/background.test.js
+++ b/tests/background.test.js
@@ -151,6 +151,7 @@ describe("moveMessages()", function() {
             accountId: "blaa",
             path: "blub",
             name: "blub",
+            id: "parentFolderId"
             // subFolders: []
         }
         messenger.folders.getSubFolders.mockImplementation(async () => {
@@ -166,6 +167,7 @@ describe("moveMessages()", function() {
             accountId: "blaa",
             path: "blub.peter",
             name: "peter",
+            folderId: "xyz"
             // subFolders: []
         }
 
@@ -176,9 +178,9 @@ describe("moveMessages()", function() {
 
         moveMessages(parentFolder, mailMapping);
 
-        await expect(messenger.folders.getSubFolders).toHaveBeenCalledWith(parentFolder, false);
-        await expect(messenger.folders.create).toHaveBeenCalledWith(parentFolder, "peter");
-        await expect(messenger.messages.move).toHaveBeenCalledWith(mailIds, newFolder);
+        await expect(messenger.folders.getSubFolders).toHaveBeenCalledWith(parentFolder.id, false);
+        await expect(messenger.folders.create).toHaveBeenCalledWith(parentFolder.id, "peter");
+        await expect(messenger.messages.move).toHaveBeenCalledWith(mailIds, newFolder.id);
     })
 
     it("should create new folder with dot replacement if necessary", async function() {
@@ -186,6 +188,7 @@ describe("moveMessages()", function() {
             accountId: "blaa",
             path: "blub",
             name: "blub",
+            id: "parentFolderId"
             // subFolders: []
         }
         messenger.folders.getSubFolders.mockImplementation(async () => {
@@ -201,6 +204,7 @@ describe("moveMessages()", function() {
             accountId: "blaa",
             path: "blub.peterDOThansDOTwurst",
             name: "peterDOThansDOTwurst",
+            id: "xyz"
             // subFolders: []
         }
 
@@ -211,8 +215,8 @@ describe("moveMessages()", function() {
 
         moveMessages(parentFolder, mailMapping);
 
-        await expect(messenger.folders.getSubFolders).toHaveBeenCalledWith(parentFolder, false);
-        await expect(messenger.folders.create).toHaveBeenCalledWith(parentFolder, "peterDOThansDOTwurst");
-        await expect(messenger.messages.move).toHaveBeenCalledWith(mailIds, newFolder);
+        await expect(messenger.folders.getSubFolders).toHaveBeenCalledWith(parentFolder.id, false);
+        await expect(messenger.folders.create).toHaveBeenCalledWith(parentFolder.id, "peterDOThansDOTwurst");
+        await expect(messenger.messages.move).toHaveBeenCalledWith(mailIds, newFolder.id);
     })
 });


### PR DESCRIPTION

    make compatible with Thunderbird v128
    change to manifestV3
    npm audit fixes

First of all, thank you for your work on this extension.
When I tried to test it with Thunderbird v128, I got the attached error messages. The latest Thunderbird version seems to no longer fully support some parts of v2.
The PR is my first work with Thunderbird extensions, so I may have overlooked something.

Fixed errors:
![messages_ ist](https://github.com/user-attachments/assets/2fd00e52-f01a-447a-85d8-7ad3aafebbaa)
![deprecated](https://github.com/user-attachments/assets/6b0b51f6-b1c8-4ce9-8bf0-9f6ed918946b)
![deprecated2](https://github.com/user-attachments/assets/9eea18ec-cc31-4e82-a3ca-4548526cdfcb)
